### PR TITLE
feat : 투숙 엔티티 및 더미데이터 8000건생성 , 예약 엔티티 및 더미데이터 수정

### DIFF
--- a/src/main/java/com/gaekdam/gaekdambe/reservation_service/reservation/command/domain/entity/Reservation.java
+++ b/src/main/java/com/gaekdam/gaekdambe/reservation_service/reservation/command/domain/entity/Reservation.java
@@ -79,9 +79,9 @@ public class Reservation {
 
 
 
-    public static Reservation create(
-            LocalDate checkinDate,
-            LocalDate checkoutDate,
+    public static Reservation createReservation(
+            LocalDate checkin,
+            LocalDate checkout,
             int guestCount,
             String guestType,
             String reservationChannel,
@@ -90,23 +90,24 @@ public class Reservation {
             Long tenantCode,
             Long roomCode,
             Long customerCode,
-            Long packageCode
+            Long packageCode,
+            String reservationStatus
     ) {
         LocalDateTime now = LocalDateTime.now();
 
-        BigDecimal total =
+        BigDecimal totalPrice =
                 roomPrice.add(packagePrice != null ? packagePrice : BigDecimal.ZERO);
 
         return Reservation.builder()
-                .reservationStatus("RESERVED")
-                .checkinDate(checkinDate)
-                .checkoutDate(checkoutDate)
+                .reservationStatus(reservationStatus)
+                .checkinDate(checkin)
+                .checkoutDate(checkout)
                 .guestCount(guestCount)
                 .guestType(guestType)
                 .reservationChannel(reservationChannel)
                 .reservationRoomPrice(roomPrice)
                 .reservationPackagePrice(packagePrice)
-                .totalPrice(total)
+                .totalPrice(totalPrice)
                 .reservedAt(now)
                 .createdAt(now)
                 .tenantCode(tenantCode)

--- a/src/main/java/com/gaekdam/gaekdambe/reservation_service/reservation/command/infrastructure/repository/ReservationRepository.java
+++ b/src/main/java/com/gaekdam/gaekdambe/reservation_service/reservation/command/infrastructure/repository/ReservationRepository.java
@@ -3,5 +3,8 @@ package com.gaekdam.gaekdambe.reservation_service.reservation.command.infrastruc
 import com.gaekdam.gaekdambe.reservation_service.reservation.command.domain.entity.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ReservationRepository extends JpaRepository<Reservation,Long> {
+    List<Reservation> findByReservationStatus(String reservationStatus);
 }

--- a/src/main/java/com/gaekdam/gaekdambe/reservation_service/stay/command/domain/entity/Stay.java
+++ b/src/main/java/com/gaekdam/gaekdambe/reservation_service/stay/command/domain/entity/Stay.java
@@ -1,0 +1,76 @@
+package com.gaekdam.gaekdambe.reservation_service.stay.command.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "stay")
+public class Stay {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "stay_code")
+    private Long stayCode;
+
+    @Column(name = "stay_status", nullable = false, length = 20)
+    private String stayStatus; // STAYING, COMPLETED
+
+    @Column(name = "actual_checkin_at")
+    private LocalDateTime actualCheckinAt;
+
+    @Column(name = "actual_checkout_at")
+    private LocalDateTime actualCheckoutAt;
+
+    @Column(name = "guest_count", nullable = false)
+    private int guestCount;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    // FK
+    @Column(name = "reservation_code", nullable = false)
+    private Long reservationCode;
+
+    @Column(name = "room_code", nullable = false)
+    private Long roomCode;
+
+    @Column(name = "customer_code", nullable = false)
+    private Long customerCode;
+
+    /* 생성 메서드 */
+    public static Stay createStay(
+            Long reservationCode,
+            Long roomCode,
+            Long customerCode,
+            int guestCount,
+            LocalDateTime checkinAt,
+            LocalDateTime checkoutAt,
+            String stayStatus
+    ) {
+        LocalDateTime now = LocalDateTime.now();
+
+        return Stay.builder()
+                .reservationCode(reservationCode)
+                .roomCode(roomCode)
+                .customerCode(customerCode)
+                .guestCount(guestCount)
+                .stayStatus(stayStatus)
+                .actualCheckinAt(checkinAt)
+                .actualCheckoutAt(checkoutAt)
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+    }
+}

--- a/src/main/java/com/gaekdam/gaekdambe/reservation_service/stay/command/infrastructure/repository/StayRepository.java
+++ b/src/main/java/com/gaekdam/gaekdambe/reservation_service/stay/command/infrastructure/repository/StayRepository.java
@@ -1,0 +1,10 @@
+package com.gaekdam.gaekdambe.reservation_service.stay.command.infrastructure.repository;
+
+import com.gaekdam.gaekdambe.reservation_service.reservation.command.domain.entity.Reservation;
+import com.gaekdam.gaekdambe.reservation_service.stay.command.domain.entity.Stay;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface StayRepository extends JpaRepository<Stay,Long> {
+}

--- a/src/test/java/com/gaekdam/gaekdambe/dummy/reservation_service/reservation/DummyReservationDataTest.java
+++ b/src/test/java/com/gaekdam/gaekdambe/dummy/reservation_service/reservation/DummyReservationDataTest.java
@@ -26,13 +26,22 @@ public class DummyReservationDataTest {
     void createReservationDummy(){
 
         Random random = new Random();
-
         int totalCount = 10_000;
 
         for (int i = 1; i <= totalCount; i++) {
 
-            long tenantCode = (i % 10) + 1; // 호텔 1~10
-            long roomCode = random.nextInt(500) + 1; // 객실 1~500
+            // 상태 결정
+            String reservationStatus;
+            if (i <= 1_200) {
+                reservationStatus = "NO_SHOW";
+            } else if (i <= 2_000) {
+                reservationStatus = "CANCELED";
+            } else {
+                reservationStatus = "RESERVED";
+            }
+
+            long tenantCode = (i % 10) + 1;
+            long roomCode = random.nextInt(500) + 1;
             long customerCode = random.nextInt(5_000) + 1;
 
             boolean hasPackage = random.nextBoolean();
@@ -49,7 +58,8 @@ public class DummyReservationDataTest {
             LocalDate checkin = LocalDate.now().minusDays(random.nextInt(60));
             LocalDate checkout = checkin.plusDays(1 + random.nextInt(3));
 
-            Reservation reservation = Reservation.create(
+            // 예약 생성
+            Reservation reservation = Reservation.createReservation(
                     checkin,
                     checkout,
                     1 + random.nextInt(4),
@@ -60,8 +70,32 @@ public class DummyReservationDataTest {
                     tenantCode,
                     roomCode,
                     customerCode,
-                    packageCode
+                    packageCode,
+                    reservationStatus
             );
+
+            // 취소 상태면 취소 시간 세팅
+            if ("CANCELED".equals(reservationStatus)) {
+                reservation = Reservation.builder()
+                        .reservationCode(reservation.getReservationCode())
+                        .reservationStatus(reservation.getReservationStatus())
+                        .checkinDate(reservation.getCheckinDate())
+                        .checkoutDate(reservation.getCheckoutDate())
+                        .guestCount(reservation.getGuestCount())
+                        .guestType(reservation.getGuestType())
+                        .reservationChannel(reservation.getReservationChannel())
+                        .reservationRoomPrice(reservation.getReservationRoomPrice())
+                        .reservationPackagePrice(reservation.getReservationPackagePrice())
+                        .totalPrice(reservation.getTotalPrice())
+                        .reservedAt(reservation.getReservedAt())
+                        .canceledAt(reservation.getReservedAt().plusHours(1 + random.nextInt(72)))
+                        .createdAt(reservation.getCreatedAt())
+                        .tenantCode(reservation.getTenantCode())
+                        .roomCode(reservation.getRoomCode())
+                        .customerCode(reservation.getCustomerCode())
+                        .packageCode(reservation.getPackageCode())
+                        .build();
+            }
 
             reservationRepository.save(reservation);
         }

--- a/src/test/java/com/gaekdam/gaekdambe/dummy/reservation_service/stay/DummyStayDataTest.java
+++ b/src/test/java/com/gaekdam/gaekdambe/dummy/reservation_service/stay/DummyStayDataTest.java
@@ -1,0 +1,72 @@
+package com.gaekdam.gaekdambe.dummy.reservation_service.stay;
+
+import com.gaekdam.gaekdambe.reservation_service.reservation.command.domain.entity.Reservation;
+import com.gaekdam.gaekdambe.reservation_service.reservation.command.infrastructure.repository.ReservationRepository;
+import com.gaekdam.gaekdambe.reservation_service.stay.command.domain.entity.Stay;
+import com.gaekdam.gaekdambe.reservation_service.stay.command.infrastructure.repository.StayRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Random;
+
+@SpringBootTest
+@Transactional
+@Rollback(false)
+public class DummyStayDataTest {
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Autowired
+    private StayRepository stayRepository;
+
+    @Test
+    @DisplayName("투숙 더미 데이터 8000건 생성 (예약 데이터 먼저 생성 후 하셔야 됩니다)")
+    void createStayDummy() {
+
+        Random random = new Random();
+
+        // RESERVED 상태 예약만 투숙 생성
+        List<Reservation> reservations =
+                reservationRepository.findByReservationStatus("RESERVED");
+
+        int count = 0;
+
+        for (Reservation reservation : reservations) {
+            if (count >= 8_000) break;
+
+            // 실제 체크인 시간 (예약 체크인 날짜, 14~16시)
+            LocalDateTime checkinAt =
+                    reservation.getCheckinDate().atTime(14 + random.nextInt(3), 0);
+
+            boolean completed = random.nextBoolean();
+
+            // 실제 체크아웃 시간은 예약 checkout_date를 넘어가지 않음
+            LocalDateTime checkoutAt =
+                    completed
+                            ? reservation.getCheckoutDate().atTime(10 + random.nextInt(2), 0)
+                            : null;
+
+            String stayStatus = completed ? "COMPLETED" : "STAYING";
+
+            Stay stay = Stay.createStay(
+                    reservation.getReservationCode(),
+                    reservation.getRoomCode(),
+                    reservation.getCustomerCode(),
+                    reservation.getGuestCount(),
+                    checkinAt,
+                    checkoutAt,
+                    stayStatus
+            );
+
+            stayRepository.save(stay);
+            count++;
+        }
+    }
+}


### PR DESCRIPTION
투숙 엔티티 생성 , 더미데이터 8천건 생성 했습니다
예약들어온 건 중 취소 , 노쇼 의 데이터는 빼고 투숙에 집어넣는 데이터라
생성하실때 예약더미데이터 부터 생성 하시고 투숙 데이터 넣어주셔야 됩니다.

// 예약 엔티티 , 더미데이터 일부 수정 했습니다