### PR TITLE
feat : 체크인아웃 엔티티 및 더미데이터 생성

### DIFF
--- a/src/main/java/com/gaekdam/gaekdambe/reservation_service/stay/command/domain/entity/CheckInOut.java
+++ b/src/main/java/com/gaekdam/gaekdambe/reservation_service/stay/command/domain/entity/CheckInOut.java
@@ -1,0 +1,63 @@
+package com.gaekdam.gaekdambe.reservation_service.stay.command.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "checkinout")
+public class CheckInOut {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "checkinout_code")
+    private Long checkinoutCode;
+
+    @Column(name = "record_type", nullable = false, length = 20)
+    private String recordType; // CHECK_IN, CHECK_OUT
+
+    @Column(name = "recorded_at", nullable = false)
+    private LocalDateTime recordedAt;
+
+    @Column(name = "record_channel", length = 20)
+    private String recordChannel; // FRONT, KIOSK, MOBILE
+
+    @Column(name = "guest_count", nullable = false)
+    private int guestCount;
+
+    @Column(name = "car_number", length = 20)
+    private String carNumber;
+
+    @Column(name = "settlement_yn", nullable = false, length = 2)
+    private String settlementYn; // Y, N
+
+    @Column(name = "stay_code", nullable = false)
+    private Long stayCode;
+
+
+    /* 생성 메서드 */
+    public static CheckInOut createCheckInOut(
+            String recordType,
+            LocalDateTime recordedAt,
+            int guestCount,
+            String recordChannel,
+            String settlementYn,
+            Long stayCode
+    ) {
+        return CheckInOut.builder()
+                .recordType(recordType)
+                .recordedAt(recordedAt)
+                .guestCount(guestCount)
+                .recordChannel(recordChannel)
+                .settlementYn(settlementYn)
+                .stayCode(stayCode)
+                .build();
+    }
+}

--- a/src/main/java/com/gaekdam/gaekdambe/reservation_service/stay/command/infrastructure/repository/CheckInOutRepository.java
+++ b/src/main/java/com/gaekdam/gaekdambe/reservation_service/stay/command/infrastructure/repository/CheckInOutRepository.java
@@ -1,0 +1,7 @@
+package com.gaekdam.gaekdambe.reservation_service.stay.command.infrastructure.repository;
+
+import com.gaekdam.gaekdambe.reservation_service.stay.command.domain.entity.CheckInOut;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CheckInOutRepository extends JpaRepository<CheckInOut,Long> {
+}

--- a/src/test/java/com/gaekdam/gaekdambe/dummy/reservation_service/stay/DummyCheckInOutDataTest.java
+++ b/src/test/java/com/gaekdam/gaekdambe/dummy/reservation_service/stay/DummyCheckInOutDataTest.java
@@ -1,0 +1,67 @@
+package com.gaekdam.gaekdambe.dummy.reservation_service.stay;
+
+import com.gaekdam.gaekdambe.reservation_service.stay.command.domain.entity.CheckInOut;
+import com.gaekdam.gaekdambe.reservation_service.stay.command.domain.entity.Stay;
+import com.gaekdam.gaekdambe.reservation_service.stay.command.infrastructure.repository.CheckInOutRepository;
+import com.gaekdam.gaekdambe.reservation_service.stay.command.infrastructure.repository.StayRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Random;
+
+@SpringBootTest
+@Transactional
+@Rollback(false)
+public class DummyCheckInOutDataTest {
+
+
+    @Autowired
+    private StayRepository stayRepository;
+
+    @Autowired
+    private CheckInOutRepository checkInOutRepository;
+
+    @Test
+    @DisplayName("체크인/체크아웃 더미 데이터 생성 투숙 상태에따라 데이터 상이")
+    void createCheckInOutDummy() {
+
+        Random random = new Random();
+        String[] channels = {"FRONT", "KIOSK", "MOBILE"};
+
+        List<Stay> stays = stayRepository.findAll();
+
+        for (Stay stay : stays) {
+
+            // CHECK_IN
+            checkInOutRepository.save(
+                    CheckInOut.createCheckInOut(
+                            "CHECK_IN",
+                            stay.getActualCheckinAt(),
+                            stay.getGuestCount(),
+                            channels[random.nextInt(channels.length)],
+                            "N",
+                            stay.getStayCode()
+                    )
+            );
+
+            // CHECK_OUT (완료된 투숙만)
+            if ("COMPLETED".equals(stay.getStayStatus())) {
+                checkInOutRepository.save(
+                        CheckInOut.createCheckInOut(
+                                "CHECK_OUT",
+                                stay.getActualCheckoutAt(),
+                                stay.getGuestCount(),
+                                channels[random.nextInt(channels.length)],
+                                "Y",
+                                stay.getStayCode()
+                        )
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
체크인아웃 엔티티 수정 생성 및 더이데이터 생성 했습니다
데이터 갯수는 약 1만2천개로 투숙 데이터의 상태에따라 상이합니다
투숙 테이블의 상태를 보고 가져오는게 있어서 
더미데이터 생성 순서는 현재는 예약 -> 투숙 -> 체크인 입니다