### PR TITLE
더미데이터 대량추가 분포및 년도 , 생성방식 변경

### DIFF
--- a/src/main/java/com/gaekdam/gaekdambe/reservation_service/reservation/command/infrastructure/repository/ReservationRepository.java
+++ b/src/main/java/com/gaekdam/gaekdambe/reservation_service/reservation/command/infrastructure/repository/ReservationRepository.java
@@ -17,4 +17,11 @@ public interface ReservationRepository extends JpaRepository<Reservation,Long> {
         where r.reservationCode = :reservationCode
     """)
     Long findPropertyCodeByReservationCode(Long reservationCode);;
+
+    @Query("""
+        select r.propertyCode
+        from Reservation r
+        where r.reservationCode = :reservationCode
+    """)
+    Long findPackageCodeByReservationCode(Long reservationCode);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,8 +20,17 @@ spring:
     open-in-view: false
     properties:
       hibernate:
-        format_sql: true
-        show_sql: true
+        # saveAll()을 실제 JDBC batch insert로 묶어주는 옵션
+        jdbc:
+          batch_size: 500
+        # 같은 테이블 insert/update를 묶어 배치 효율 증가
+        order_inserts: true
+        order_updates: true
+
+        # 더미 생성시 SQL 로그가 (속도 위해 OFF )
+        format_sql: false
+        show_sql: false
+
         dialect: org.hibernate.dialect.MariaDBDialect
 
   sql:

--- a/src/test/java/com/gaekdam/gaekdambe/dummy/DummyDataRunnerTest.java
+++ b/src/test/java/com/gaekdam/gaekdambe/dummy/DummyDataRunnerTest.java
@@ -34,6 +34,7 @@ import com.gaekdam.gaekdambe.dummy.generate.operation_service.room.DummyRoomType
 import com.gaekdam.gaekdambe.dummy.generate.reservation_service.reservation.DummyReservationDataTest;
 import com.gaekdam.gaekdambe.dummy.generate.reservation_service.stay.DummyCheckInOutDataTest;
 import com.gaekdam.gaekdambe.dummy.generate.reservation_service.stay.DummyStayDataTest;
+import org.springframework.util.StopWatch;
 
 @SpringBootTest
 @Rollback(value = false)
@@ -111,60 +112,68 @@ class DummyDataRunnerTest {
     @Autowired ReportTemplateWidgetGenerator reportTemplateWidgetGenerator;
 
 
-
-
+    // 시간측정위한 메서드
+    private void run(StopWatch sw, String name, Runnable task) {
+        sw.start(name);
+        try {
+            task.run();
+        } finally {
+            sw.stop();
+        }
+    }
 
     @Test
     void generateAll() {
+        StopWatch sw = new StopWatch("DummyDataGenerate");
+
         System.out.println(">>> generateAll called");
 
-        // 호텔서비스
-        hotelGroupDataTest.generate();
-        propertyDataTest.generate();
-        departmentDataTest.generate();
-        positionDataTest.generate();
+        // 호텔 서비스
+        run(sw, "hotelGroup", hotelGroupDataTest::generate);
+        run(sw, "property", propertyDataTest::generate);
+        run(sw, "department", departmentDataTest::generate);
+        run(sw, "position", positionDataTest::generate);
 
-        // iam서비스
-        permissionTypeDataTest.generate();
-        permissionDataTest.generate();
-        permissionMappingDataTest.generate();
-        employeeDataTest.generate();
+        // IAM 서비스
+        run(sw, "permissionType", permissionTypeDataTest::generate);
+        run(sw, "permission", permissionDataTest::generate);
+        run(sw, "permissionMapping", permissionMappingDataTest::generate);
+        run(sw, "employee", employeeDataTest::generate);
 
         // 오퍼레이션 서비스
-        facilityDataTest.generate();
-        reservationPackageDataTest.generate();
-        roomDataTest.generate();
-        roomTypeDataTest.generate();
+        run(sw, "facility", facilityDataTest::generate);
+        run(sw, "reservationPackage", reservationPackageDataTest::generate);
+        run(sw, "room", roomDataTest::generate);
+        run(sw, "roomType", roomTypeDataTest::generate);
 
         // 고객 서비스
-        customerDataTest.generate();
-        membershipDataTest.generate();
-        loyaltyDataTest.generate();
+        run(sw, "customer", customerDataTest::generate);
+        run(sw, "membership", membershipDataTest::generate);
+        run(sw, "loyalty", loyaltyDataTest::generate);
 
         // 예약 서비스
-        reservationDataTest.generate();
-        stayDataTest.generate();
-        checkInOutDataTest.generate();
+        run(sw, "reservation(100k)", reservationDataTest::generate);
+        run(sw, "stay", stayDataTest::generate);
+        run(sw, "checkInOut", checkInOutDataTest::generate);
 
-        // 부대시설이용
-        facilityUsageDataTest.generate();
+        // 부대시설 이용
+        run(sw, "facilityUsage", facilityUsageDataTest::generate);
 
+        // 커뮤니케이션 서비스
+        run(sw, "incident", incidentDataTest::generate);
+        run(sw, "inquiryCategory", inquiryCategoryDataTest::generate);
+        run(sw, "inquiry", inquiryDataTest::generate);
+        run(sw, "messageStage", messageJourneyStageSetupTest::generate);
+        run(sw, "messageTemplate", messageTemplateSetupTest::generate);
+        run(sw, "messageRule", messageRuleSetupTest::generate);
+        run(sw, "messageSendHistory", messageSendHistoryDataTest::generate);
 
-        // communication_service (문의, 사건, 메세지 더미데이터 생성)
-        incidentDataTest.generate();
-        inquiryCategoryDataTest.generate();
-        inquiryDataTest.generate();
-        messageJourneyStageSetupTest.generate();
-        messageTemplateSetupTest.generate();
-        messageRuleSetupTest.generate();
-        messageSendHistoryDataTest.generate();
+        // 분석 서비스
+        run(sw, "reportKpiDataset", reportKpiDatasetGenerator::generate);
+        run(sw, "reportTemplate", reportTemplateGenerator::generate);
+        run(sw, "reportTemplateWidget", reportTemplateWidgetGenerator::generate);
 
-        // analytics_service (dashboard/report dummy data)
-        reportKpiDatasetGenerator.generate();
-        reportTemplateGenerator.generate();
-        reportTemplateWidgetGenerator.generate();
-
-
-
+        System.out.println(sw.prettyPrint());
     }
+
 }

--- a/src/test/java/com/gaekdam/gaekdambe/dummy/generate/reservation_service/reservation/DummyReservationDataTest.java
+++ b/src/test/java/com/gaekdam/gaekdambe/dummy/generate/reservation_service/reservation/DummyReservationDataTest.java
@@ -3,10 +3,14 @@ package com.gaekdam.gaekdambe.dummy.generate.reservation_service.reservation;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.stream.Collectors;
+
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -23,132 +27,184 @@ import com.gaekdam.gaekdambe.reservation_service.reservation.command.domain.enum
 import com.gaekdam.gaekdambe.reservation_service.reservation.command.infrastructure.repository.ReservationPackageRepository;
 import com.gaekdam.gaekdambe.reservation_service.reservation.command.infrastructure.repository.ReservationRepository;
 
-import jakarta.transaction.Transactional;
-
 @Component
 public class DummyReservationDataTest {
 
-    @Autowired
-    ReservationRepository reservationRepository;
-    @Autowired
-    RoomRepository roomRepository;
-    @Autowired
-    RoomTypeRepository roomTypeRepository;
-    @Autowired
-    ReservationPackageRepository packageRepository;
+    private static final int TOTAL = 100_000; // 전체 예약 목표 건수
+    private static final int BATCH = 500;     // JDBC batch + flush 주기
+
+    @Autowired ReservationRepository reservationRepository;
+    @Autowired RoomRepository roomRepository;
+    @Autowired RoomTypeRepository roomTypeRepository;
+    @Autowired ReservationPackageRepository packageRepository;
+    @Autowired EntityManager em;
 
     @Transactional
     public void generate() {
 
+        // 이미 데이터가 있으면 중복 생성 방지
         if (reservationRepository.count() > 0) return;
 
-        LocalDate today = LocalDate.now();
         Random random = new Random();
 
+        // 더미 생성 중 반복 조회 방지를 위해 고정 데이터 캐싱
         List<Room> rooms = roomRepository.findAll();
         List<RoomType> roomTypes = roomTypeRepository.findAll();
 
+        // propertyCode 기준 패키지 목록 캐싱
         Map<Long, List<ReservationPackage>> packagesByProperty =
                 packageRepository.findAll()
                         .stream()
-                        .collect(Collectors.groupingBy(ReservationPackage::getPropertyCode));
+                        .collect(Collectors.groupingBy(
+                                ReservationPackage::getPropertyCode
+                        ));
 
-        int total = 10_000;
+        // 생성 기간 (월 단위 분포)
+        LocalDate start = LocalDate.of(2024, 1, 1);
+        LocalDate end   = LocalDate.of(2026, 12, 31);
 
-        for (int i = 0; i < total; i++) {
+        int months = 36;
+        int basePerMonth = TOTAL / months;
 
-            Room room = rooms.get(random.nextInt(rooms.size()));
-            RoomType roomType = roomTypes.stream()
-                    .filter(rt -> rt.getRoomTypeCode().equals(room.getRoomTypeCode()))
-                    .findFirst()
-                    .orElseThrow();
+        // saveAll + flush/clear 를 위한 버퍼
+        List<Reservation> buffer = new ArrayList<>(BATCH);
 
-            ReservationStatus status;
-            LocalDate checkin;
-            LocalDate checkout;
+        LocalDate cursor = start;
 
-            // choose a package for this property's reservation if available
-            Long chosenPackageCode = null;
-            BigDecimal chosenPackagePrice = BigDecimal.ZERO;
-            List<ReservationPackage> pkgs = packagesByProperty.get(roomType.getPropertyCode());
+        while (!cursor.isAfter(end)) {
 
+            // 월별 생성량에 변동을 주어 데이터가 균일하지 않게
+            int monthVolume =
+                    Math.max(basePerMonth + random.nextInt(600) - 300, 300);
 
-            boolean usePackage = pkgs != null && !pkgs.isEmpty() && random.nextDouble() < 0.4;
-
-            if (usePackage) {
-                ReservationPackage pkg = pkgs.get(random.nextInt(pkgs.size()));
-                if (pkg != null) {
-                    chosenPackageCode = pkg.getPackageCode();
-                    chosenPackagePrice = pkg.getPackagePrice() != null
-                            ? pkg.getPackagePrice() : BigDecimal.ZERO;
+            // === [추가] 최근 운영 데이터 체감 보정 ===
+            // 2026년 1~2월은 Today / Operation 화면에서
+            // 데이터가 부족해 보이지 않도록 소폭 증량
+            if (cursor.getYear() == 2026) {
+                if (cursor.getMonthValue() == 1) {
+                    monthVolume = (int) (monthVolume * 1.20); // 1월 +20%
+                } else if (cursor.getMonthValue() == 2) {
+                    monthVolume = (int) (monthVolume * 1.15); // 2월 +15%
                 }
             }
 
+            // 월별 상태 비율
+            double cancelRate  = 0.05 + random.nextDouble() * 0.10;
+            double noShowRate  = 0.03 + random.nextDouble() * 0.07;
+            double packageRate = 0.20 + random.nextDouble() * 0.40;
 
-            LocalDateTime canceledAt = null;
+            for (int i = 0; i < monthVolume; i++) {
 
-            if (i < 800) {
-                // 취소
-                status = ReservationStatus.CANCELED;
-                checkin = today.plusDays(1 + random.nextInt(30));
-                checkout = checkin.plusDays(1 + random.nextInt(5));
-                // set canceled_at after reservedAt later (reservedAt computed below)
-            } else {
-                // default to RESERVED; some will be NO_SHOW
-                status = ReservationStatus.RESERVED;
+                // 랜덤 객실 → 해당 객실의 룸타입
+                Room room = rooms.get(random.nextInt(rooms.size()));
+                RoomType roomType = roomTypes.stream()
+                        .filter(rt -> rt.getRoomTypeCode().equals(room.getRoomTypeCode()))
+                        .findFirst()
+                        .orElseThrow();
 
-                int mod = (i - 800) % 4;
+                // 체크인/체크아웃 (1~5박)
+                int lastDay = cursor.lengthOfMonth();
+                LocalDate checkin =
+                        cursor.withDayOfMonth(1 + random.nextInt(lastDay));
+                LocalDate checkout =
+                        checkin.plusDays(1 + random.nextInt(5));
 
-                if (mod == 0) {                 // 체크인 예정
-                    checkin = today.plusDays(1);
-                    checkout = checkin.plusDays(1 + random.nextInt(5));
-                } else if (mod == 1) {          // 투숙중
-                    checkin = today.minusDays(1 + random.nextInt(3));
-                    checkout = today.plusDays(1 + random.nextInt(3));
-                } else if (mod == 2) {          // 정상 완료
-                    checkin = today.minusDays(10 + random.nextInt(10));
-                    checkout = checkin.plusDays(1 + random.nextInt(5));
-                } else {                       // 노쇼 후보 (과거 + Stay 없음)
-                    checkin = today.minusDays(5 + random.nextInt(5));
-                    checkout = checkin.plusDays(1 + random.nextInt(3));
-                    // some of these become NO_SHOW
-                    if (random.nextDouble() < 0.6) {
-                        status = ReservationStatus.NO_SHOW;
-                    }
+                // 예약 상태 결정
+                ReservationStatus status = ReservationStatus.RESERVED;
+                double r = random.nextDouble();
+                if (r < cancelRate) status = ReservationStatus.CANCELED;
+                else if (r < cancelRate + noShowRate) status = ReservationStatus.NO_SHOW;
+
+                // 인원 수 생성
+                int guestCount =
+                        1 + random.nextInt(roomType.getMaxCapacity());
+
+                // 인원 수에 따른 GuestType 보정
+                GuestType guestType;
+                if (guestCount == 1) {
+                    guestType = GuestType.INDIVIDUAL;
+                } else if (guestCount <= 4) {
+                    guestType = GuestType.FAMILY;
+                } else {
+                    guestType = GuestType.GROUP;
+                }
+
+                // 예약 채널 분포 (WEB / OTA / PHONE)
+                ReservationChannel channel;
+                double channelRand = random.nextDouble();
+                if (channelRand < 0.50) {
+                    channel = ReservationChannel.WEB;
+                } else if (channelRand < 0.85) {
+                    channel = ReservationChannel.OTA;
+                } else {
+                    channel = ReservationChannel.PHONE;
+                }
+
+                // 패키지 선택
+                Long packageCode = null;
+                BigDecimal packagePrice = BigDecimal.ZERO;
+
+                List<ReservationPackage> pkgs =
+                        packagesByProperty.get(roomType.getPropertyCode());
+
+                if (pkgs != null && !pkgs.isEmpty()
+                        && random.nextDouble() < packageRate) {
+
+                    ReservationPackage pkg =
+                            pkgs.get(random.nextInt(pkgs.size()));
+                    packageCode = pkg.getPackageCode();
+                    packagePrice = pkg.getPackagePrice();
+                }
+
+                // 예약 생성 시각
+                LocalDateTime reservedAt =
+                        checkin.minusDays(1 + random.nextInt(30)).atTime(10, 0);
+
+                // 취소 예약만 canceledAt 설정
+                LocalDateTime canceledAt =
+                        status == ReservationStatus.CANCELED
+                                ? reservedAt.plusHours(1 + random.nextInt(48))
+                                : null;
+
+                // 예약 엔티티 생성
+                buffer.add(
+                        Reservation.builder()
+                                .reservationStatus(status)
+                                .checkinDate(checkin)
+                                .checkoutDate(checkout)
+                                .guestCount(guestCount)
+                                .guestType(guestType)
+                                .reservationChannel(channel)
+                                .reservationRoomPrice(roomType.getBasePrice())
+                                .reservationPackagePrice(packagePrice)
+                                .totalPrice(roomType.getBasePrice().add(packagePrice))
+                                .reservedAt(reservedAt)
+                                .createdAt(reservedAt)
+                                .canceledAt(canceledAt)
+                                .propertyCode(roomType.getPropertyCode())
+                                .roomCode(room.getRoomCode())
+                                .packageCode(packageCode)
+                                .customerCode((long) (random.nextInt(20_000) + 1))
+                                .build()
+                );
+
+                // 배치 단위 저장
+                if (buffer.size() == BATCH) {
+                    reservationRepository.saveAll(buffer);
+                    em.flush();
+                    em.clear();
+                    buffer.clear();
                 }
             }
 
-            LocalDateTime reservedAt =
-                    checkin.minusDays(1 + random.nextInt(14)).atTime(10, 0);
+            cursor = cursor.plusMonths(1);
+        }
 
-            // reservation_status 값이 CANCELED 이면 cancel_at 데이터를 reservedAt 시점으로 72시간 이내에 생성함
-            if (status == ReservationStatus.CANCELED) {
-                long maxHours = Math.max(1, java.time.Duration.between(reservedAt, checkin.atStartOfDay()).toHours());
-                int hours = 1 + random.nextInt((int) Math.max(1, Math.min(72, maxHours)));
-                canceledAt = reservedAt.plusHours(hours);
-            }
-
-            Reservation reservation =
-                    Reservation.builder()
-                            .reservationStatus(status)
-                            .checkinDate(checkin)
-                            .checkoutDate(checkout)
-                            .guestCount(1 + random.nextInt(roomType.getMaxCapacity()))
-                            .guestType(GuestType.INDIVIDUAL)
-                            .reservationChannel(ReservationChannel.WEB)
-                            .reservationRoomPrice(roomType.getBasePrice())
-                            .reservationPackagePrice(chosenPackagePrice)
-                            .totalPrice(roomType.getBasePrice().add(chosenPackagePrice != null ? chosenPackagePrice : BigDecimal.ZERO))
-                            .reservedAt(reservedAt)
-                            .createdAt(reservedAt)
-                            .canceledAt(canceledAt)
-                            .propertyCode(roomType.getPropertyCode())
-                            .roomCode(room.getRoomCode())
-                            .packageCode(chosenPackageCode)
-                            .customerCode((long) (random.nextInt(5_000) + 1))
-                            .build();
-
-            reservationRepository.save(reservation);
+        // 남은 데이터 처리
+        if (!buffer.isEmpty()) {
+            reservationRepository.saveAll(buffer);
+            em.flush();
+            em.clear();
         }
     }
 }

--- a/src/test/java/com/gaekdam/gaekdambe/dummy/generate/reservation_service/stay/DummyCheckInOutDataTest.java
+++ b/src/test/java/com/gaekdam/gaekdambe/dummy/generate/reservation_service/stay/DummyCheckInOutDataTest.java
@@ -7,34 +7,43 @@ import com.gaekdam.gaekdambe.reservation_service.stay.command.domain.enums.Check
 import com.gaekdam.gaekdambe.reservation_service.stay.command.domain.enums.SettlementYn;
 import com.gaekdam.gaekdambe.reservation_service.stay.command.infrastructure.repository.CheckInOutRepository;
 import com.gaekdam.gaekdambe.reservation_service.stay.command.infrastructure.repository.StayRepository;
+import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 @Component
 public class DummyCheckInOutDataTest {
 
+    private static final int BATCH = 500;
+
+    @Autowired StayRepository stayRepository;
+    @Autowired CheckInOutRepository checkInOutRepository;
     @Autowired
-    StayRepository stayRepository;
-    @Autowired
-    CheckInOutRepository checkInOutRepository;
+    EntityManager em;
 
     @Transactional
     public void generate() {
 
+        // [가드] 중복 생성 방지
         if (checkInOutRepository.count() > 0) return;
 
         Random random = new Random();
         CheckInOutChannel[] channels = CheckInOutChannel.values();
 
+        List<CheckInOut> buffer = new ArrayList<>(BATCH);
+
+        // [대상] stay가 있어야 checkin/out 생성 가능
         for (Stay stay : stayRepository.findAll()) {
 
-            //  실제 체크인한 투숙만
+            // [실제 체크인한 투숙만] 체크인 시간이 없으면 스킵
             if (stay.getActualCheckinAt() == null) continue;
 
-            // CHECK_IN (무조건 1건)
-            checkInOutRepository.save(
+            // [체크인] 무조건 1건 생성
+            buffer.add(
                     CheckInOut.createCheckInOut(
                             CheckInOutRecordType.CHECK_IN,
                             stay.getActualCheckinAt(),
@@ -45,9 +54,9 @@ public class DummyCheckInOutDataTest {
                     )
             );
 
-            // CHECK_OUT (완료된 투숙만)
+            // [체크아웃] completed(= actualCheckoutAt 존재)인 경우만 1건 생성
             if (stay.getActualCheckoutAt() != null) {
-                checkInOutRepository.save(
+                buffer.add(
                         CheckInOut.createCheckInOut(
                                 CheckInOutRecordType.CHECK_OUT,
                                 stay.getActualCheckoutAt(),
@@ -58,6 +67,21 @@ public class DummyCheckInOutDataTest {
                         )
                 );
             }
+
+            // [배치 저장]
+            if (buffer.size() >= BATCH) {
+                checkInOutRepository.saveAll(buffer);
+                em.flush();
+                em.clear();
+                buffer.clear();
+            }
+        }
+
+        // [마지막 찌꺼기]
+        if (!buffer.isEmpty()) {
+            checkInOutRepository.saveAll(buffer);
+            em.flush();
+            em.clear();
         }
     }
 }

--- a/src/test/java/com/gaekdam/gaekdambe/dummy/generate/reservation_service/stay/DummyStayDataTest.java
+++ b/src/test/java/com/gaekdam/gaekdambe/dummy/generate/reservation_service/stay/DummyStayDataTest.java
@@ -6,47 +6,59 @@ import com.gaekdam.gaekdambe.reservation_service.reservation.command.infrastruct
 import com.gaekdam.gaekdambe.reservation_service.stay.command.domain.entity.Stay;
 import com.gaekdam.gaekdambe.reservation_service.stay.command.domain.enums.StayStatus;
 import com.gaekdam.gaekdambe.reservation_service.stay.command.infrastructure.repository.StayRepository;
+import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
 @Component
 public class DummyStayDataTest {
 
+    private static final int BATCH = 500;
+
     @Autowired ReservationRepository reservationRepository;
     @Autowired StayRepository stayRepository;
+    @Autowired
+    EntityManager em;
 
     @Transactional
     public void generate() {
 
+        // [가드] 이미 있으면 중복 생성 방지
         if (stayRepository.count() > 0) return;
 
         LocalDate today = LocalDate.now();
+        Random random = new Random();
 
-        List<Reservation> reservations =
-                reservationRepository.findByReservationStatus(ReservationStatus.RESERVED);
+        List<Stay> buffer = new ArrayList<>(BATCH);
 
-        for (Reservation r : reservations) {
+        // [대상] RESERVED 예약만 stay 후보 (취소/노쇼는 stay 생성 X)
+        for (Reservation r :
+                reservationRepository.findByReservationStatus(ReservationStatus.RESERVED)) {
 
-            // 미래 예약 → 투숙 없음
+            // [미래 예약] 체크인일이 오늘 이후면 아직 투숙 시작 전 → stay 생성 안 함
             if (r.getCheckinDate().isAfter(today)) continue;
 
 
+            // [체크인/아웃] 체크인은 15시 고정, 체크아웃은 과거면 10시로 생성
             LocalDateTime checkinAt = r.getCheckinDate().atTime(15, 0);
-            LocalDateTime checkoutAt = null;
-            StayStatus stayStatus = StayStatus.STAYING;
 
+            LocalDateTime checkoutAt = null;
+            StayStatus status = StayStatus.STAYING;
+
+            // [완료 투숙] 체크아웃일이 과거면 completed 처리
             if (r.getCheckoutDate().isBefore(today)) {
                 checkoutAt = r.getCheckoutDate().atTime(10, 0);
-                stayStatus = StayStatus.COMPLETED;
+                status = StayStatus.COMPLETED;
             }
 
-            stayRepository.save(
+            buffer.add(
                     Stay.createStay(
                             r.getReservationCode(),
                             r.getRoomCode(),
@@ -54,9 +66,24 @@ public class DummyStayDataTest {
                             r.getGuestCount(),
                             checkinAt,
                             checkoutAt,
-                            stayStatus
+                            status
                     )
             );
+
+            // [배치 저장] 메모리/속도 개선
+            if (buffer.size() == BATCH) {
+                stayRepository.saveAll(buffer);
+                em.flush();
+                em.clear();
+                buffer.clear();
+            }
+        }
+
+        // [마지막 찌꺼기]
+        if (!buffer.isEmpty()) {
+            stayRepository.saveAll(buffer);
+            em.flush();
+            em.clear();
         }
     }
 }


### PR DESCRIPTION
2024.1 ~ 2026.12 까지 예약데이터 범위 설정 , 투숙 ,체크인아웃, 부대시설이용까지 같이 변경
예약데이터 약 10만건 (월 최소단위로 생성하게 해놓은게 있어서 정확히 10만건 x 조금 더 들어갑니다)
현재는 2026 1월 2월 기준으로 분포를 조금 더 들어가게 해놓았습니다

기존 jpa방식의 더미데이터 생성 OOM 발생(메모리초과)
-> 하이버네이트 BATCH 기능 사용 , 각각의 save 단위를 묶어서 saveAll 로 한번에 insert
-> 루프문에 flush/clear 를 사용하여 jpa 영속성 컨텐츠 캐시 초기화
-> 테스트단위 sql문 보이지않게 false 설정

테스트별 걸리는 시간 체크 추가 -> 더미데이터 generateAll 하면 마지막에 각각 얼마나 걸렸나 로그 찍힐겁니다